### PR TITLE
Makes sure to convert HTML entities on the title of the post

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -28,7 +28,7 @@ module Jobs
 
       def poll_feed
         topics_polled_from_feed.each do |topic|
-          TopicEmbed.import(author, topic.url, topic.title, CGI.unescapeHTML(topic.content)) if topic.content.present?
+          TopicEmbed.import(author, topic.url, CGI.unescapeHTML(topic.title), CGI.unescapeHTML(topic.content)) if topic.content.present?
         end
       end
 


### PR DESCRIPTION
The plugin currently converts html entities in the body, this adds
the same conversion to the title to avoind encoding issues